### PR TITLE
First version of the mutual TLS interface

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+# Description
+
+Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+## Checklist
+
+- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
+- [ ] I have performed a self-review of my own code.
+- [ ] I have made corresponding changes to the documentation.
+- [ ] I have added tests that validate the behaviour of the software.
+- [ ] I validated that new and existing unit tests pass locally with my changes.
+- [ ] Any dependent changes have been merged and published in downstream modules.
+- [ ] I have bumped the version of any required library.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,72 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
+  schedule:
+    - cron: '17 22 * * 0'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'python' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        
+        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+        
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
+    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+
+    # - run: |
+    #   echo "Run, Build Application using script"
+    #   ./location_of_script_within_repo/buildscript.sh
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+
+jobs:
+  lint-report:
+    name: Lint report
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install tox
+        run: pip install tox
+      - name: Run tests using tox
+        run: tox -e lint
+
+  static-analysis:
+    name: Static analysis
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install tox
+        run: pip install tox
+      - name: Run tests using tox
+        run: tox -e static
+
+  unit-tests-with-coverage:
+    name: Unit tests
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install tox
+        run: pip install tox
+      - name: Run tests using tox
+        run: tox -e unit

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -1,0 +1,29 @@
+name: Upload mutual-tls-interface
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "lib/charms/mutual_tls_interface/v0/**"
+
+jobs:
+  charmhub-upload:
+    runs-on: ubuntu-22.04
+    name: Charmhub upload lib
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: canonical/charming-actions/upload-charm@2.2.5
+        with:
+          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          channel: "edge"
+          upload-image: "false"
+
+      - name: Publish libs
+        env:
+          CHARMCRAFT_AUTH: "${{ secrets.CHARMCRAFT_AUTH }}"
+        run: |
+          charmcraft publish-lib charms.mutual_tls_interface.v0.mutual_tls

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+venv/
+build/
+*.charm
+.tox/
+.coverage
+__pycache__/
+*.py[cod]
+.idea
+.vscode/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing
+
+## Developing
+
+Create and activate a virtualenv with the development requirements:
+
+    virtualenv -p python3 venv
+    source venv/bin/activate
+
+## Testing
+
+Testing for this project is done using `tox`. You can run the various tests like so:
+
+```shell
+tox -e lint      # code style
+tox -e static    # static analysis
+tox -e unit      # unit tests
+```

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2023 Canonical Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # mutual-tls-interface
+
+## Description
+
+This project contains libraries for use by providers and requirers of the `mutual-tls` integration. 
+
+> **Warning**: The charm located here is a placeholder charm and shouldn't be deployed.
+
+## Usage
+
+Please, refer to the [docs](https://charmhub.io/mutual-tls-interface/libraries/mutual_tls).

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,0 +1,8 @@
+type: charm
+bases:
+  - build-on:
+    - name: ubuntu
+      channel: "22.04"
+    run-on:
+    - name: ubuntu
+      channel: "22.04"

--- a/lib/charms/mutual_tls_interface/v0/mutual_tls.py
+++ b/lib/charms/mutual_tls_interface/v0/mutual_tls.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Library for the mutual-tls relation.

--- a/lib/charms/mutual_tls_interface/v0/mutual_tls.py
+++ b/lib/charms/mutual_tls_interface/v0/mutual_tls.py
@@ -185,21 +185,19 @@ class CertificateAvailableEvent(EventBase):
 def _load_relation_data(raw_relation_data: dict) -> dict:
     """Load relation data from the relation data bag.
 
-    Json loads all data.
-
     Args:
         raw_relation_data: Relation data from the databag
 
     Returns:
         dict: Relation data in dict format.
     """
-    certificate_data = {}
+    loaded_relation_data = {}
     for key in raw_relation_data:
         try:
-            certificate_data[key] = json.loads(raw_relation_data[key])
+            loaded_relation_data[key] = json.loads(raw_relation_data[key])
         except (json.decoder.JSONDecodeError, TypeError):
-            certificate_data[key] = raw_relation_data[key]
-    return certificate_data
+            loaded_relation_data[key] = raw_relation_data[key]
+    return loaded_relation_data
 
 
 class MutualTLSRequirerCharmEvents(CharmEvents):
@@ -240,7 +238,8 @@ class MutualTLSProvides(Object):
         )
         if not relation:
             raise RuntimeError(
-                f"No relation found with relation name {self.relationship_name} and relation ID {relation_id}"
+                f"No relation found with relation name {self.relationship_name} and "
+                f"relation ID {relation_id}"
             )
         relation.data[self.model.unit]["certificate"] = certificate
         relation.data[self.model.unit]["ca"] = ca

--- a/lib/charms/mutual_tls_interface/v0/mutual_tls.py
+++ b/lib/charms/mutual_tls_interface/v0/mutual_tls.py
@@ -210,7 +210,6 @@ class MutualTLSProvides:
     """Mutual TLS provider class."""
 
     def __init__(self, charm: CharmBase, relationship_name: str):
-        super().__init__(charm, relationship_name)
         self.charm = charm
         self.relationship_name = relationship_name
 

--- a/lib/charms/mutual_tls_interface/v0/mutual_tls.py
+++ b/lib/charms/mutual_tls_interface/v0/mutual_tls.py
@@ -280,7 +280,7 @@ class MutualTLSProvides:
             logger.warning("Can't remove certificate - No certificate in relation data")
 
 
-class MutualTLSRequires(Object):
+class MutualTLSRequires:
     """TLS certificates requirer class to be instantiated by TLS certificates requirers."""
 
     on = MutualTLSRequirerCharmEvents()

--- a/lib/charms/mutual_tls_interface/v0/mutual_tls.py
+++ b/lib/charms/mutual_tls_interface/v0/mutual_tls.py
@@ -1,0 +1,266 @@
+"""TODO: Add a proper docstring here.
+
+This is a placeholder docstring for this charm library. Docstrings are
+presented on Charmhub and updated whenever you push a new version of the
+library.
+
+Complete documentation about creating and documenting libraries can be found
+in the SDK docs at https://juju.is/docs/sdk/libraries.
+
+See `charmcraft publish-lib` and `charmcraft fetch-lib` for details of how to
+share and consume charm libraries. They serve to enhance collaboration
+between charmers. Use a charmer's libraries for classes that handle
+integration with their charm.
+
+Bear in mind that new revisions of the different major API versions (v0, v1,
+v2 etc) are maintained independently.  You can continue to update v0 and v1
+after you have pushed v3.
+
+Markdown is supported, following the CommonMark specification.
+"""
+
+
+import json
+import logging
+from typing import List
+
+from jsonschema import exceptions, validate  # type: ignore[import]
+from ops.charm import (
+    CharmBase,
+    CharmEvents,
+    RelationChangedEvent,
+)
+from ops.framework import EventBase, EventSource, Handle, Object
+
+# The unique Charmhub library identifier, never change it
+LIBID = "b24dab3c7b464669a7710806defe34d4"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+
+logger = logging.getLogger(__name__)
+
+
+PROVIDER_JSON_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://canonical.github.io/charm-relation-interfaces/interfaces/mutual_tls/schemas/provider.json",  # noqa: E501
+    "type": "object",
+    "title": "`mutual_tls` provider schema",
+    "description": "The `mutual_tls` root schema comprises the entire provider application databag for this interface.",  # noqa: E501
+    "default": {},
+    "examples": [
+        {
+            "certificate": "-----BEGIN CERTIFICATE-----\nMIIC6DCCAdCgAwIBAgIUW42TU9LSjEZLMCclWrvSwAsgRtcwDQYJKoZIhvcNAQEL\nBQAwIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdoYXRldmVyMB4XDTIzMDMyNDE4\nNDMxOVoXDTI0MDMyMzE4NDMxOVowPDELMAkGA1UEAwwCb2sxLTArBgNVBC0MJGUw\nNjVmMWI3LTE2OWEtNDE5YS1iNmQyLTc3OWJkOGM4NzIwNjCCASIwDQYJKoZIhvcN\nAQEBBQADggEPADCCAQoCggEBAK42ixoklDH5K5i1NxXo/AFACDa956pE5RA57wlC\nBfgUYaIDRmv7TUVJh6zoMZSD6wjSZl3QgP7UTTZeHbvs3QE9HUwEkH1Lo3a8vD3z\neqsE2vSnOkpWWnPbfxiQyrTm77/LAWBt7lRLRLdfL6WcucD3wsGqm58sWXM3HG0f\nSN7PHCZUFqU6MpkHw8DiKmht5hBgWG+Vq3Zw8MNaqpwb/NgST3yYdcZwb58G2FTS\nZvDSdUfRmD/mY7TpciYV8EFylXNNFkth8oGNLunR9adgZ+9IunfRKj1a7S5GSwXU\nAZDaojw+8k5i3ikztsWH11wAVCiLj/3euIqq95z8xGycnKcCAwEAATANBgkqhkiG\n9w0BAQsFAAOCAQEAWMvcaozgBrZ/MAxzTJmp5gZyLxmMNV6iT9dcqbwzDtDtBvA/\n46ux6ytAQ+A7Bd3AubvozwCr1Id6g66ae0blWYRRZmF8fDdX/SBjIUkv7u9A3NVQ\nXN9gsEvK9pdpfN4ZiflfGSLdhM1STHycLmhG6H5s7HklbukMRhQi+ejbSzm/wiw1\nipcxuKhSUIVNkTLusN5b+HE2gwF1fn0K0z5jWABy08huLgbaEKXJEx5/FKLZGJga\nfpIzAdf25kMTu3gggseaAmzyX3AtT1i8A8nqYfe8fnnVMkvud89kq5jErv/hlMC9\n49g5yWQR2jilYYM3j9BHDuB+Rs+YS5BCep1JnQ==\n-----END CERTIFICATE-----\n",  # noqa: E501
+            "ca": "-----BEGIN CERTIFICATE-----\nMIIC6DCCAdCgAwIBAgIUdiBwE/CtaBXJl3MArjZen6Y8kigwDQYJKoZIhvcNAQEL\nBQAwIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdoYXRldmVyMB4XDTIzMDMyNDE4\nNDg1OVoXDTI0MDMyMzE4NDg1OVowPDELMAkGA1UEAwwCb2sxLTArBgNVBC0MJDEw\nMDdjNDBhLWUwYzMtNDVlOS05YTAxLTVlYjY0NWQ0ZmEyZDCCASIwDQYJKoZIhvcN\nAQEBBQADggEPADCCAQoCggEBANOnUl6JDlXpLMRr/PxgtfE/E5Yk6E/TkPkPL/Kk\ntUGjEi42XZDg9zn3U6cjTDYu+rfKY2jiitfsduW6DQIkEpz3AvbuCMbbgnFpcjsB\nYysLSMTmuz/AVPrfnea/tQTALcONCSy1VhAjGSr81ZRSMB4khl9StSauZrbkpJ1P\nshqkFSUyAi31mKrnXz0Es/v0Yi0FzAlgWrZ4u1Ld+Bo2Xz7oK4mHf7/93Jc+tEaM\nIqG6ocD0q8bjPp0tlSxftVADNUzWlZfM6fue5EXzOsKqyDrxYOSchfU9dNzKsaBX\nkxbHEeSUPJeYYj7aVPEfAs/tlUGsoXQvwWfRie8grp2BoLECAwEAATANBgkqhkiG\n9w0BAQsFAAOCAQEACZARBpHYH6Gr2a1ka0mCWfBmOZqfDVan9rsI5TCThoylmaXW\nquEiZ2LObI+5faPzxSBhr9TjJlQamsd4ywout7pHKN8ZGqrCMRJ1jJbUfobu1n2k\nUOsY4+jzV1IRBXJzj64fLal4QhUNv341lAer6Vz3cAyRk7CK89b/DEY0x+jVpyZT\n1osx9JtsOmkDTgvdStGzq5kPKWOfjwHkmKQaZXliCgqbhzcCERppp1s/sX6K7nIh\n4lWiEmzUSD3Hngk51KGWlpZszO5KQ4cSZ3HUt/prg+tt0ROC3pY61k+m5dDUa9M8\nRtMI6iTjzSj/UV8DiAx0yeM+bKoy4jGeXmaL3g==\n-----END CERTIFICATE-----\n",  # noqa: E501
+            "chain": [
+                "-----BEGIN CERTIFICATE-----\nMIIC6DCCAdCgAwIBAgIUW42TU9LSjEZLMCclWrvSwAsgRtcwDQYJKoZIhvcNAQEL\nBQAwIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdoYXRldmVyMB4XDTIzMDMyNDE4\nNDMxOVoXDTI0MDMyMzE4NDMxOVowPDELMAkGA1UEAwwCb2sxLTArBgNVBC0MJGUw\nNjVmMWI3LTE2OWEtNDE5YS1iNmQyLTc3OWJkOGM4NzIwNjCCASIwDQYJKoZIhvcN\nAQEBBQADggEPADCCAQoCggEBAK42ixoklDH5K5i1NxXo/AFACDa956pE5RA57wlC\nBfgUYaIDRmv7TUVJh6zoMZSD6wjSZl3QgP7UTTZeHbvs3QE9HUwEkH1Lo3a8vD3z\neqsE2vSnOkpWWnPbfxiQyrTm77/LAWBt7lRLRLdfL6WcucD3wsGqm58sWXM3HG0f\nSN7PHCZUFqU6MpkHw8DiKmht5hBgWG+Vq3Zw8MNaqpwb/NgST3yYdcZwb58G2FTS\nZvDSdUfRmD/mY7TpciYV8EFylXNNFkth8oGNLunR9adgZ+9IunfRKj1a7S5GSwXU\nAZDaojw+8k5i3ikztsWH11wAVCiLj/3euIqq95z8xGycnKcCAwEAATANBgkqhkiG\n9w0BAQsFAAOCAQEAWMvcaozgBrZ/MAxzTJmp5gZyLxmMNV6iT9dcqbwzDtDtBvA/\n46ux6ytAQ+A7Bd3AubvozwCr1Id6g66ae0blWYRRZmF8fDdX/SBjIUkv7u9A3NVQ\nXN9gsEvK9pdpfN4ZiflfGSLdhM1STHycLmhG6H5s7HklbukMRhQi+ejbSzm/wiw1\nipcxuKhSUIVNkTLusN5b+HE2gwF1fn0K0z5jWABy08huLgbaEKXJEx5/FKLZGJga\nfpIzAdf25kMTu3gggseaAmzyX3AtT1i8A8nqYfe8fnnVMkvud89kq5jErv/hlMC9\n49g5yWQR2jilYYM3j9BHDuB+Rs+YS5BCep1JnQ==\n-----END CERTIFICATE-----\n",  # noqa: E501
+                "-----BEGIN CERTIFICATE-----\nMIIC6DCCAdCgAwIBAgIUdiBwE/CtaBXJl3MArjZen6Y8kigwDQYJKoZIhvcNAQEL\nBQAwIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdoYXRldmVyMB4XDTIzMDMyNDE4\nNDg1OVoXDTI0MDMyMzE4NDg1OVowPDELMAkGA1UEAwwCb2sxLTArBgNVBC0MJDEw\nMDdjNDBhLWUwYzMtNDVlOS05YTAxLTVlYjY0NWQ0ZmEyZDCCASIwDQYJKoZIhvcN\nAQEBBQADggEPADCCAQoCggEBANOnUl6JDlXpLMRr/PxgtfE/E5Yk6E/TkPkPL/Kk\ntUGjEi42XZDg9zn3U6cjTDYu+rfKY2jiitfsduW6DQIkEpz3AvbuCMbbgnFpcjsB\nYysLSMTmuz/AVPrfnea/tQTALcONCSy1VhAjGSr81ZRSMB4khl9StSauZrbkpJ1P\nshqkFSUyAi31mKrnXz0Es/v0Yi0FzAlgWrZ4u1Ld+Bo2Xz7oK4mHf7/93Jc+tEaM\nIqG6ocD0q8bjPp0tlSxftVADNUzWlZfM6fue5EXzOsKqyDrxYOSchfU9dNzKsaBX\nkxbHEeSUPJeYYj7aVPEfAs/tlUGsoXQvwWfRie8grp2BoLECAwEAATANBgkqhkiG\n9w0BAQsFAAOCAQEACZARBpHYH6Gr2a1ka0mCWfBmOZqfDVan9rsI5TCThoylmaXW\nquEiZ2LObI+5faPzxSBhr9TjJlQamsd4ywout7pHKN8ZGqrCMRJ1jJbUfobu1n2k\nUOsY4+jzV1IRBXJzj64fLal4QhUNv341lAer6Vz3cAyRk7CK89b/DEY0x+jVpyZT\n1osx9JtsOmkDTgvdStGzq5kPKWOfjwHkmKQaZXliCgqbhzcCERppp1s/sX6K7nIh\n4lWiEmzUSD3Hngk51KGWlpZszO5KQ4cSZ3HUt/prg+tt0ROC3pY61k+m5dDUa9M8\nRtMI6iTjzSj/UV8DiAx0yeM+bKoy4jGeXmaL3g==\n-----END CERTIFICATE-----\n",  # noqa: E501
+            ],
+        }
+    ],
+    "required": ["certificate"],
+    "properties": {
+        "certificate": {
+            "$id": "#/properties/certificate",
+            "type": "string",
+            "title": "Public TLS certificate",
+            "description": "Public TLS certificate",
+        },
+        "ca": {
+            "$id": "#/properties/ca",
+            "type": "string",
+            "title": "CA public TLS certificate",
+            "description": "CA Public TLS certificate",
+        },
+        "chain": {
+            "$id": "#/properties/chain",
+            "type": "array",
+            "items": {"type": "string", "$id": "#/properties/chain/items"},
+            "title": "CA public TLS certificate chain",
+            "description": "CA public TLS certificate chain",
+        },
+    },
+    "additionalProperties": True,
+}
+
+
+class CertificateAvailableEvent(EventBase):
+    """Charm Event triggered when a TLS certificate is available."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        certificate: str,
+        ca: str,
+        chain: List[str],
+    ):
+        super().__init__(handle)
+        self.certificate = certificate
+        self.ca = ca
+        self.chain = chain
+
+    def snapshot(self) -> dict:
+        """Return snapshot."""
+        return {
+            "certificate": self.certificate,
+            "ca": self.ca,
+            "chain": self.chain,
+        }
+
+    def restore(self, snapshot: dict):
+        """Restores snapshot."""
+        self.certificate = snapshot["certificate"]
+        self.ca = snapshot["ca"]
+        self.chain = snapshot["chain"]
+
+
+def _load_relation_data(raw_relation_data: dict) -> dict:
+    """Load relation data from the relation data bag.
+
+    Json loads all data.
+
+    Args:
+        raw_relation_data: Relation data from the databag
+
+    Returns:
+        dict: Relation data in dict format.
+    """
+    certificate_data = {}
+    for key in raw_relation_data:
+        try:
+            certificate_data[key] = json.loads(raw_relation_data[key])
+        except (json.decoder.JSONDecodeError, TypeError):
+            certificate_data[key] = raw_relation_data[key]
+    return certificate_data
+
+
+class MutualTLSRequirerCharmEvents(CharmEvents):
+    """List of events that the Mutual TLS requirer charm can leverage."""
+
+    certificate_available = EventSource(CertificateAvailableEvent)
+
+
+class MutualTLSProvides(Object):
+    """Mutual TLS provider class."""
+
+    def __init__(self, charm: CharmBase, relationship_name: str):
+        super().__init__(charm, relationship_name)
+        self.charm = charm
+        self.relationship_name = relationship_name
+
+    def set_certificate(
+        self,
+        certificate: str,
+        ca: str,
+        chain: List[str],
+        relation_id: int = None,
+    ) -> None:
+        """Add certificates to relation data.
+
+        Args:
+            certificate (str): Certificate
+            ca (str): CA Certificate
+            chain (list): CA Chain
+            relation_id (int): Juju relation ID
+
+        Returns:
+            None
+        """
+        relation = self.model.get_relation(
+            relation_name=self.relationship_name,
+            relation_id=relation_id,
+        )
+        relation.data[self.model.unit]["certificate"] = certificate
+        relation.data[self.model.unit]["ca"] = ca
+        relation.data[self.model.unit]["chain"] = json.dumps(chain)
+
+    def remove_certificate(self, relation_id: int = None) -> None:
+        """Remove a given certificate from relation data.
+
+        Args:
+            relation_id (int): Relation ID
+
+        Returns:
+            None
+        """
+        relation = self.model.get_relation(
+            relation_name=self.relationship_name,
+            relation_id=relation_id,
+        )
+        relation.data[self.model.unit].pop("certificate")
+        relation.data[self.model.unit].pop("ca")
+        relation.data[self.model.unit].pop("chain")
+
+
+class MutualTLSRequires(Object):
+    """TLS certificates requirer class to be instantiated by TLS certificates requirers."""
+
+    on = MutualTLSRequirerCharmEvents()
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relationship_name: str,
+    ):
+        """Generates/use private key and observes relation changed event.
+
+        Args:
+            charm: Charm object
+            relationship_name: Juju relation name
+        """
+        super().__init__(charm, relationship_name)
+        self.relationship_name = relationship_name
+        self.charm = charm
+        self.framework.observe(
+            charm.on[relationship_name].relation_changed, self._on_relation_changed
+        )
+
+    @staticmethod
+    def _relation_data_is_valid(certificates_data: dict) -> bool:
+        """Return whether relation data is valid based on json schema.
+
+        Args:
+            certificates_data: Certificate data in dict format.
+
+        Returns:
+            bool: Whether relation data is valid.
+        """
+        try:
+            validate(instance=certificates_data, schema=PROVIDER_JSON_SCHEMA)
+            return True
+        except exceptions.ValidationError:
+            return False
+
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Emit certificate available event.
+
+        Args:
+            event: Juju event
+
+        Returns:
+            None
+        """
+        relation = self.model.get_relation(self.relationship_name, relation_id=event.relation.id)
+        if not relation:
+            logger.warning(f"No relation: {self.relationship_name}")
+            return
+        if not relation.app:
+            logger.warning(f"No remote app in relation: {self.relationship_name}")
+            return
+        provider_relation_data = _load_relation_data(relation.data[relation.app])
+        if not self._relation_data_is_valid(provider_relation_data):
+            logger.warning(
+                f"Provider relation data did not pass JSON Schema validation: "
+                f"{event.relation.data[relation.app]}"
+            )
+            return
+        self.on.certificate_available.emit(
+            certificate=provider_relation_data["certificate"],
+            ca=provider_relation_data["ca"],
+            chain=provider_relation_data["chain"],
+        )

--- a/lib/charms/mutual_tls_interface/v0/mutual_tls.py
+++ b/lib/charms/mutual_tls_interface/v0/mutual_tls.py
@@ -206,7 +206,7 @@ class MutualTLSRequirerCharmEvents(CharmEvents):
     certificate_available = EventSource(CertificateAvailableEvent)
 
 
-class MutualTLSProvides(Object):
+class MutualTLSProvides:
     """Mutual TLS provider class."""
 
     def __init__(self, charm: CharmBase, relationship_name: str):

--- a/lib/charms/mutual_tls_interface/v0/mutual_tls.py
+++ b/lib/charms/mutual_tls_interface/v0/mutual_tls.py
@@ -297,7 +297,6 @@ class MutualTLSRequires(Object):
             charm: Charm object
             relationship_name: Juju relation name
         """
-        super().__init__(charm, relationship_name)
         self.relationship_name = relationship_name
         self.charm = charm
         self.framework.observe(

--- a/lib/charms/mutual_tls_interface/v0/mutual_tls.py
+++ b/lib/charms/mutual_tls_interface/v0/mutual_tls.py
@@ -12,9 +12,6 @@ From a charm directory, fetch the library using `charmcraft`:
 charmcraft fetch-lib charms.mutual_tls_interface.v0.mutual_tls
 ```
 
-Add the following libraries to the charm's `requirements.txt` file:
-- jsonschema
-
 ### Provider charm
 The provider charm is the charm providing public certificates to another charm that requires them.
 
@@ -104,6 +101,8 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 LIBPATCH = 1
+
+PYDEPS = ["jsonschema"]
 
 
 logger = logging.getLogger(__name__)
@@ -206,10 +205,11 @@ class MutualTLSRequirerCharmEvents(CharmEvents):
     certificate_available = EventSource(CertificateAvailableEvent)
 
 
-class MutualTLSProvides:
+class MutualTLSProvides(Object):
     """Mutual TLS provider class."""
 
     def __init__(self, charm: CharmBase, relationship_name: str):
+        super().__init__(charm, relationship_name)
         self.charm = charm
         self.relationship_name = relationship_name
 
@@ -280,7 +280,7 @@ class MutualTLSProvides:
             logger.warning("Can't remove certificate - No certificate in relation data")
 
 
-class MutualTLSRequires:
+class MutualTLSRequires(Object):
     """TLS certificates requirer class to be instantiated by TLS certificates requirers."""
 
     on = MutualTLSRequirerCharmEvents()
@@ -296,6 +296,7 @@ class MutualTLSRequires:
             charm: Charm object
             relationship_name: Juju relation name
         """
+        super().__init__(charm, relationship_name)
         self.relationship_name = relationship_name
         self.charm = charm
         self.framework.observe(

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,0 +1,7 @@
+name: mutual-tls-interface
+
+display-name: Mutual TLS Interface
+
+summary: Placeholder charm
+
+description: Placeholder charm.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,39 @@
+# Testing tools configuration
+[tool.coverage.run]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+log_cli_level = "INFO"
+
+# Formatting tools configuration
+[tool.black]
+line-length = 99
+target-version = ["py38"]
+
+# Linting tools configuration
+[tool.ruff]
+line-length = 99
+select = ["E", "W", "F", "C", "N", "D", "I001"]
+extend-ignore = [
+    "D203",
+    "D204",
+    "D213",
+    "D215",
+    "D400",
+    "D404",
+    "D406",
+    "D407",
+    "D408",
+    "D409",
+    "D413",
+]
+ignore = ["E501", "D107"]
+extend-exclude = ["__pycache__", "*.egg_info"]
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
+
+[tool.ruff.mccabe]
+max-complexity = 10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,10 @@ max-line-length = 99
 max-doc-length = 99
 exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
 select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore W503, E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107", "E203"]
+ignore = ["D107"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103"]
+per-file-ignores = ["tests/*:D100,D101,D102"]
 docstring-convention = "google"
 # Check for properly formatted copyright header in each file
 copyright-check = "True"
@@ -30,7 +29,7 @@ copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
 [tool.mypy]
 pretty = true
 python_version = 3.8
-mypy_path = "$MYPY_CONFIG_FILE_DIR/src:$MYPY_CONFIG_FILE_DIR/lib:$MYPY_CONFIG_FILE_DIR/tests/unit"
+mypy_path = "$MYPY_CONFIG_FILE_DIR/lib:$MYPY_CONFIG_FILE_DIR/tests/unit"
 follow_imports = "normal"
 warn_redundant_casts = true
 warn_unused_ignores = true
@@ -44,7 +43,7 @@ allow_redefinition = true
 
 # Ignore libraries that do not have type hint nor stubs
 [[tool.mypy.overrides]]
-module = ["ops.*", "kubernetes.*", "flatten_json.*", "git.*"]
+module = ["ops.*","flatten_json.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,39 +1,52 @@
-# Testing tools configuration
 [tool.coverage.run]
 branch = true
 
 [tool.coverage.report]
 show_missing = true
 
-[tool.pytest.ini_options]
-minversion = "6.0"
-log_cli_level = "INFO"
-
-# Formatting tools configuration
 [tool.black]
 line-length = 99
 target-version = ["py38"]
 
-# Linting tools configuration
-[tool.ruff]
-line-length = 99
-select = ["E", "W", "F", "C", "N", "D", "I001"]
-extend-ignore = [
-    "D203",
-    "D204",
-    "D213",
-    "D215",
-    "D400",
-    "D404",
-    "D406",
-    "D407",
-    "D408",
-    "D409",
-    "D413",
-]
-ignore = ["E501", "D107"]
-extend-exclude = ["__pycache__", "*.egg_info"]
-per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
+[tool.isort]
+profile = "black"
 
-[tool.ruff.mccabe]
-max-complexity = 10
+[tool.flake8]
+max-line-length = 99
+max-doc-length = 99
+exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
+select = ["E", "W", "F", "C", "N", "R", "D", "H"]
+# Ignore W503, E501 because using black creates errors with this
+# Ignore D107 Missing docstring in __init__
+ignore = ["W503", "E501", "D107", "E203"]
+# D100, D101, D102, D103: Ignore missing docstrings in tests
+per-file-ignores = ["tests/*:D100,D101,D102,D103"]
+docstring-convention = "google"
+# Check for properly formatted copyright header in each file
+copyright-check = "True"
+copyright-author = "Canonical Ltd."
+copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
+
+[tool.mypy]
+pretty = true
+python_version = 3.8
+mypy_path = "$MYPY_CONFIG_FILE_DIR/src:$MYPY_CONFIG_FILE_DIR/lib:$MYPY_CONFIG_FILE_DIR/tests/unit"
+follow_imports = "normal"
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_unused_configs = true
+show_traceback = true
+show_error_codes = true
+namespace_packages = true
+explicit_package_bases = true
+check_untyped_defs = true
+allow_redefinition = true
+
+# Ignore libraries that do not have type hint nor stubs
+[[tool.mypy.overrides]]
+module = ["ops.*", "kubernetes.*", "flatten_json.*", "git.*"]
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+log_cli_level = "INFO"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+ops
+jsonschema

--- a/src/charm.py
+++ b/src/charm.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Placeholder charm."""
+
+from ops.charm import CharmBase
+from ops.main import main
+
+
+class PlaceholderCharm(CharmBase):
+    """Placeholder charm."""
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+
+if __name__ == "__main__":
+    main(PlaceholderCharm)

--- a/tests/unit/charms/mutual_tls_interface/v0/dummy_provider_charm/metadata.yaml
+++ b/tests/unit/charms/mutual_tls_interface/v0/dummy_provider_charm/metadata.yaml
@@ -1,0 +1,11 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: mutual-tls-interface-provider
+
+description: Dummy mutual-tls-interface-provider.
+summary: Dummy mutual-tls-interface-provider.
+
+provides:
+  certificates:
+    interface: mutual-tls

--- a/tests/unit/charms/mutual_tls_interface/v0/dummy_provider_charm/src/charm.py
+++ b/tests/unit/charms/mutual_tls_interface/v0/dummy_provider_charm/src/charm.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from ops.charm import CharmBase
+from ops.charm import CharmBase, RelationJoinedEvent
 from ops.main import main
 
 from lib.charms.mutual_tls_interface.v0.mutual_tls import MutualTLSProvides
@@ -11,6 +11,15 @@ class DummyMutualTLSProviderCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
         self.mutual_tls = MutualTLSProvides(self, "certificates")
+        self.framework.observe(
+            self.on.certificates_relation_joined, self._on_certificates_relation_joined
+        )
+
+    def _on_certificates_relation_joined(self, event: RelationJoinedEvent):
+        certificate = "my certificate"
+        ca = "my CA certificate"
+        chain = ["certificate 1", "certificate 2"]
+        self.mutual_tls.set_certificate(certificate=certificate, ca=ca, chain=chain)
 
 
 if __name__ == "__main__":

--- a/tests/unit/charms/mutual_tls_interface/v0/dummy_provider_charm/src/charm.py
+++ b/tests/unit/charms/mutual_tls_interface/v0/dummy_provider_charm/src/charm.py
@@ -1,0 +1,17 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from ops.charm import CharmBase
+from ops.main import main
+
+from lib.charms.mutual_tls_interface.v0.mutual_tls import MutualTLSProvides
+
+
+class DummyMutualTLSProviderCharm(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.mutual_tls = MutualTLSProvides(self, "certificates")
+
+
+if __name__ == "__main__":
+    main(DummyMutualTLSProviderCharm)

--- a/tests/unit/charms/mutual_tls_interface/v0/dummy_requirer_charm/metadata.yaml
+++ b/tests/unit/charms/mutual_tls_interface/v0/dummy_requirer_charm/metadata.yaml
@@ -1,0 +1,11 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: mutual-tls-interface-requirer
+
+description: Dummy mutual-tls-interface-requirer.
+summary: Dummy mutual-tls-interface-requirer.
+
+requires:
+  certificates:
+    interface: mutual-tls

--- a/tests/unit/charms/mutual_tls_interface/v0/dummy_requirer_charm/src/charm.py
+++ b/tests/unit/charms/mutual_tls_interface/v0/dummy_requirer_charm/src/charm.py
@@ -1,0 +1,28 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from ops.charm import CharmBase
+from ops.main import main
+
+from lib.charms.mutual_tls_interface.v0.mutual_tls import (
+    CertificateAvailableEvent,
+    MutualTLSRequires,
+)
+
+
+class DummyMutualTLSRequirerCharm(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.mutual_tls = MutualTLSRequires(self, "certificates")
+        self.framework.observe(
+            self.mutual_tls.on.certificate_available, self._on_certificate_available
+        )
+
+    def _on_certificate_available(self, event: CertificateAvailableEvent):
+        print(event.certificate)
+        print(event.ca)
+        print(event.chain)
+
+
+if __name__ == "__main__":
+    main(DummyMutualTLSRequirerCharm)

--- a/tests/unit/charms/mutual_tls_interface/v0/test_mutual_tls_provides.py
+++ b/tests/unit/charms/mutual_tls_interface/v0/test_mutual_tls_provides.py
@@ -1,0 +1,118 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import json
+import unittest
+
+from ops import testing
+
+from tests.unit.charms.mutual_tls_interface.v0.dummy_provider_charm.src.charm import (
+    DummyMutualTLSProviderCharm,
+)
+
+
+class TestMutualTLSProvides(unittest.TestCase):
+    def setUp(self):
+        self.unit_name = "mutual-tls-interface-provider/0"
+        self.harness = testing.Harness(DummyMutualTLSProviderCharm)
+        self.addCleanup(self.harness.cleanup)
+        self.harness.begin()
+
+    def create_mutual_tls_relation(self) -> int:
+        relation_name = "certificates"
+        remote_app_name = "mutual-tls-requirer"
+        relation_id = self.harness.add_relation(
+            relation_name=relation_name,
+            remote_app=remote_app_name,
+        )
+        return relation_id
+
+    def test_given_mutual_tls_relation_exists_when_set_certificate_then_certificate_added_to_relation_data(  # noqa: E501
+        self,
+    ):
+        relation_id = self.create_mutual_tls_relation()
+
+        certificate = "whatever cert"
+        ca = "whatever ca"
+        chain = ["whatever cert 1", "whatever cert 2"]
+
+        self.harness.charm.mutual_tls.set_certificate(
+            certificate=certificate, ca=ca, chain=chain, relation_id=relation_id
+        )
+
+        relation_data = self.harness.get_relation_data(
+            app_or_unit="mutual-tls-interface-provider/0",
+            relation_id=relation_id,
+        )
+        self.assertEqual(relation_data["certificate"], certificate)
+        self.assertEqual(relation_data["ca"], ca)
+        self.assertEqual(relation_data["chain"], json.dumps(chain))
+
+    def test_given_relation_id_not_provided_and_mutual_tls_relation_exists_when_set_certificate_then_certificate_added_to_relation_data(  # noqa: E501
+        self,
+    ):
+        relation_id = self.create_mutual_tls_relation()
+
+        certificate = "whatever cert"
+        ca = "whatever ca"
+        chain = ["whatever cert 1", "whatever cert 2"]
+
+        self.harness.charm.mutual_tls.set_certificate(certificate=certificate, ca=ca, chain=chain)
+
+        relation_data = self.harness.get_relation_data(
+            app_or_unit="mutual-tls-interface-provider/0",
+            relation_id=relation_id,
+        )
+        self.assertEqual(relation_data["certificate"], certificate)
+        self.assertEqual(relation_data["ca"], ca)
+        self.assertEqual(relation_data["chain"], json.dumps(chain))
+
+    def test_given_mutual_tls_relation_exists_when_remove_certificate_then_certificate_removed_from_relation_data(  # noqa: E501
+        self,
+    ):
+        relation_id = self.create_mutual_tls_relation()
+        relation_data = {
+            "certificate": "whatever cert",
+            "ca": "whatever ca",
+            "chain": json.dumps(["cert 1", "cert 2"]),
+        }
+        self.harness.update_relation_data(
+            relation_id=relation_id,
+            key_values=relation_data,
+            app_or_unit="mutual-tls-interface-provider/0",
+        )
+
+        self.harness.charm.mutual_tls.remove_certificate(relation_id=relation_id)
+
+        relation_data = self.harness.get_relation_data(
+            app_or_unit="mutual-tls-interface-provider/0",
+            relation_id=relation_id,
+        )
+        assert "certificate" not in relation_data
+        assert "ca" not in relation_data
+        assert "chain" not in relation_data
+
+    def test_given_mutual_tls_relation_exists_and_id_not_provided_when_remove_certificate_then_certificate_removed_from_relation_data(  # noqa: E501
+        self,
+    ):
+        relation_id = self.create_mutual_tls_relation()
+        relation_data = {
+            "certificate": "whatever cert",
+            "ca": "whatever ca",
+            "chain": json.dumps(["cert 1", "cert 2"]),
+        }
+        self.harness.update_relation_data(
+            relation_id=relation_id,
+            key_values=relation_data,
+            app_or_unit="mutual-tls-interface-provider/0",
+        )
+
+        self.harness.charm.mutual_tls.remove_certificate()
+
+        relation_data = self.harness.get_relation_data(
+            app_or_unit="mutual-tls-interface-provider/0",
+            relation_id=relation_id,
+        )
+        assert "certificate" not in relation_data
+        assert "ca" not in relation_data
+        assert "chain" not in relation_data

--- a/tests/unit/charms/mutual_tls_interface/v0/test_mutual_tls_requires.py
+++ b/tests/unit/charms/mutual_tls_interface/v0/test_mutual_tls_requires.py
@@ -32,7 +32,7 @@ class TestMutualTLSRequires(unittest.TestCase):
         return relation_id
 
     @patch(f"{BASE_CHARM_DIR}._on_certificate_available")  # noqa: E501
-    def test_given_certificate_in_relation_data_when_relation_changed_then_certificate_available_event_is_emitted(  # noqa: E501
+    def test_given_certificates_in_relation_data_when_relation_changed_then_certificate_available_event_is_emitted(  # noqa: E501
         self, patch_certificate_available
     ):
         remote_unit_name = "mutual-tls-provider/0"
@@ -57,7 +57,28 @@ class TestMutualTLSRequires(unittest.TestCase):
         assert certificate_available_event.ca == ca
         assert certificate_available_event.chain == chain
 
-    def test_given_badly_formatted_relation_data_when_relation_changed_then_warning_log_is_emitted(
+    @patch(f"{BASE_CHARM_DIR}._on_certificate_available")  # noqa: E501
+    def test_given_only_certificate_in_relation_data_when_relation_changed_then_certificate_available_event_is_emitted(  # noqa: E501
+        self, patch_certificate_available
+    ):
+        remote_unit_name = "mutual-tls-provider/0"
+        relation_id = self.create_mutual_tls_relation()
+        self.harness.add_relation_unit(relation_id=relation_id, remote_unit_name=remote_unit_name)
+        certificate = "whatever certificate"
+        key_values = {
+            "certificate": certificate,
+        }
+        self.harness.update_relation_data(
+            relation_id=relation_id, app_or_unit=remote_unit_name, key_values=key_values
+        )
+
+        args, _ = patch_certificate_available.call_args
+        certificate_available_event = args[0]
+        assert certificate_available_event.certificate == certificate
+        assert certificate_available_event.ca is None
+        assert certificate_available_event.chain is None
+
+    def test_given_none_of_the_expected_keys_in_relation_data_when_relation_changed_then_warning_log_is_emitted(  # noqa: E501
         self,
     ):
         remote_unit_name = "mutual-tls-provider/0"
@@ -73,4 +94,16 @@ class TestMutualTLSRequires(unittest.TestCase):
                 relation_id=relation_id, app_or_unit=remote_unit_name, key_values=key_values
             )
 
-            assert "Provider relation data did not pass JSON Schema validation" in log.output[0]
+        assert "Provider relation data did not pass JSON Schema validation" in log.output[0]
+
+    def test_given_provider_uses_application_relation_data_when_relation_changed_then_log_is_emitted(  # noqa: E501
+        self,
+    ):
+        relation_id = self.create_mutual_tls_relation()
+        key_values = {"certificate": "whatever cert"}
+        with self.assertLogs(BASE_LIB_DIR, level="INFO") as log:
+            self.harness.update_relation_data(
+                relation_id=relation_id, app_or_unit="mutual-tls-provider", key_values=key_values
+            )
+
+        assert "No remote unit in relation" in log.output[0]

--- a/tests/unit/charms/mutual_tls_interface/v0/test_mutual_tls_requires.py
+++ b/tests/unit/charms/mutual_tls_interface/v0/test_mutual_tls_requires.py
@@ -1,0 +1,76 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import json
+import unittest
+from unittest.mock import patch
+
+from ops import testing
+
+from tests.unit.charms.mutual_tls_interface.v0.dummy_requirer_charm.src.charm import (
+    DummyMutualTLSRequirerCharm,
+)
+
+BASE_LIB_DIR = "lib.charms.mutual_tls_interface.v0.mutual_tls"
+BASE_CHARM_DIR = "tests.unit.charms.mutual_tls_interface.v0.dummy_requirer_charm.src.charm.DummyMutualTLSRequirerCharm"  # noqa: E501
+
+
+class TestMutualTLSRequires(unittest.TestCase):
+    def setUp(self):
+        self.unit_name = "mutual-tls-interface-requirer/0"
+        self.harness = testing.Harness(DummyMutualTLSRequirerCharm)
+        self.addCleanup(self.harness.cleanup)
+        self.harness.begin()
+
+    def create_mutual_tls_relation(self) -> int:
+        relation_name = "certificates"
+        remote_app_name = "mutual-tls-provider"
+        relation_id = self.harness.add_relation(
+            relation_name=relation_name,
+            remote_app=remote_app_name,
+        )
+        return relation_id
+
+    @patch(f"{BASE_CHARM_DIR}._on_certificate_available")  # noqa: E501
+    def test_given_certificate_in_relation_data_when_relation_changed_then_certificate_available_event_is_emitted(  # noqa: E501
+        self, patch_certificate_available
+    ):
+        remote_unit_name = "mutual-tls-provider/0"
+        relation_id = self.create_mutual_tls_relation()
+        self.harness.add_relation_unit(relation_id=relation_id, remote_unit_name=remote_unit_name)
+        certificate = "whatever certificate"
+        ca = "whatever CA certificate"
+        chain = ["cert1", "cert2"]
+        chain_string = json.dumps(chain)
+        key_values = {
+            "certificate": certificate,
+            "ca": ca,
+            "chain": chain_string,
+        }
+        self.harness.update_relation_data(
+            relation_id=relation_id, app_or_unit=remote_unit_name, key_values=key_values
+        )
+
+        args, _ = patch_certificate_available.call_args
+        certificate_available_event = args[0]
+        assert certificate_available_event.certificate == certificate
+        assert certificate_available_event.ca == ca
+        assert certificate_available_event.chain == chain
+
+    def test_given_badly_formatted_relation_data_when_relation_changed_then_warning_log_is_emitted(
+        self,
+    ):
+        remote_unit_name = "mutual-tls-provider/0"
+        relation_id = self.create_mutual_tls_relation()
+        self.harness.add_relation_unit(relation_id=relation_id, remote_unit_name=remote_unit_name)
+        key_values = {
+            "banana": "whatever banana content",
+            "pizza": "whatever pizza content",
+        }
+
+        with self.assertLogs(BASE_LIB_DIR, level="WARNING") as log:
+            self.harness.update_relation_data(
+                relation_id=relation_id, app_or_unit=remote_unit_name, key_values=key_values
+            )
+
+            assert "Provider relation data did not pass JSON Schema validation" in log.output[0]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,67 @@
+# Copyright 2023 guillaume
+# See LICENSE file for licensing details.
+
+[tox]
+skipsdist=True
+skip_missing_interpreters = True
+envlist = fmt, lint, unit
+
+[vars]
+tst_path = {toxinidir}/tests/
+lib_path = {toxinidir}/lib/charms/mutual_tls_interface
+all_path = {[vars]lib_path} {[vars]tst_path}
+
+[testenv]
+setenv =
+  PYTHONPATH = {toxinidir}:{toxinidir}/lib
+  PYTHONBREAKPOINT=pdb.set_trace
+  PY_COLORS=1
+passenv =
+  PYTHONPATH
+  CHARM_BUILD_DIR
+  MODEL_SETTINGS
+
+[testenv:fmt]
+description = Apply coding style standards to code
+deps =
+    black
+    ruff
+commands =
+    black {[vars]all_path}
+    ruff --fix {[vars]all_path}
+
+[testenv:lint]
+description = Check code against coding style standards
+deps =
+    black
+    ruff
+    codespell
+commands =
+    # uncomment the following line if this charm owns a lib
+    # codespell {[vars]lib_path}
+    codespell {toxinidir} \
+              --skip {toxinidir}/.git \
+              --skip {toxinidir}/.tox \
+              --skip {toxinidir}/build \
+              --skip {toxinidir}/lib \
+              --skip {toxinidir}/venv \
+              --skip {toxinidir}/.mypy_cache \
+              --skip {toxinidir}/icon.svg
+    
+    ruff {[vars]all_path}
+    black --check --diff {[vars]all_path}
+
+[testenv:unit]
+description = Run unit tests
+deps =
+    pytest
+    coverage[toml]
+    -r{toxinidir}/requirements.txt
+commands =
+    coverage run --source={[vars]lib_path} \
+                 -m pytest \
+                 --tb native \
+                 -v \
+                 -s \
+                 {posargs}
+    coverage report

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 [tox]
 skipsdist=True

--- a/tox.ini
+++ b/tox.ini
@@ -1,55 +1,56 @@
-# Copyright 2023 guillaume
+# Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
-
 [tox]
 skipsdist=True
 skip_missing_interpreters = True
-envlist = fmt, lint, unit
+envlist = lint, static, unit
 
 [vars]
-tst_path = {toxinidir}/tests/
-lib_path = {toxinidir}/lib/charms/mutual_tls_interface
-all_path = {[vars]lib_path} {[vars]tst_path}
+lib_path = {toxinidir}/lib/
+unit_test_path = {toxinidir}/tests/unit
+all_path = {[vars]lib_path} {[vars]unit_test_path}
 
 [testenv]
 setenv =
-  PYTHONPATH = {toxinidir}:{toxinidir}/lib
-  PYTHONBREAKPOINT=pdb.set_trace
-  PY_COLORS=1
+    PYTHONPATH = {toxinidir}:{toxinidir}/lib
+    PYTHONBREAKPOINT=ipdb.set_trace
 passenv =
-  PYTHONPATH
-  CHARM_BUILD_DIR
-  MODEL_SETTINGS
-
-[testenv:fmt]
-description = Apply coding style standards to code
-deps =
-    black
-    ruff
-commands =
-    black {[vars]all_path}
-    ruff --fix {[vars]all_path}
+    PYTHONPATH
+    HOME
+    CHARM_BUILD_DIR
+    MODEL_SETTINGS
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
     black
-    ruff
-    codespell
+    flake8 == 4.0.1
+    flake8-docstrings
+    flake8-copyright
+    flake8-builtins
+    pyproject-flake8
+    pep8-naming
+    isort
 commands =
-    # uncomment the following line if this charm owns a lib
-    # codespell {[vars]lib_path}
-    codespell {toxinidir} \
-              --skip {toxinidir}/.git \
-              --skip {toxinidir}/.tox \
-              --skip {toxinidir}/build \
-              --skip {toxinidir}/lib \
-              --skip {toxinidir}/venv \
-              --skip {toxinidir}/.mypy_cache \
-              --skip {toxinidir}/icon.svg
-    
-    ruff {[vars]all_path}
+    pflake8 {[vars]all_path}
+    isort --check-only --diff {[vars]all_path}
     black --check --diff {[vars]all_path}
+
+[testenv:static]
+description = Run static analysis checks
+deps =
+    -r{toxinidir}/requirements.txt
+    mypy
+    types-PyYAML
+    pytest
+    pytest-operator
+    juju
+    types-setuptools
+    types-toml
+setenv =
+    PYTHONPATH = ""
+commands =
+    mypy {[vars]lib_path} {posargs}
 
 [testenv:unit]
 description = Run unit tests
@@ -58,10 +59,5 @@ deps =
     coverage[toml]
     -r{toxinidir}/requirements.txt
 commands =
-    coverage run --source={[vars]lib_path} \
-                 -m pytest \
-                 --tb native \
-                 -v \
-                 -s \
-                 {posargs}
+    coverage run --source={[vars]lib_path} -m pytest -v --tb native {[vars]unit_test_path} -s {posargs}
     coverage report


### PR DESCRIPTION
### Overview
Some charms require knowledge of other charms' public TLS certificates for trusted communication with them. This library can be used by any charm claiming to be able to authenticate (or be authenticated) through TLS communication.

### Reference
- [Mutual TLS charm relation interface](https://github.com/canonical/charm-relation-interfaces/tree/main/interfaces/mutual_tls/v0). 