### PR TITLE
[feat] Changes interface name to cert transfer

### DIFF
--- a/lib/charms/mutual_tls_interface/v0/mutual_tls.py
+++ b/lib/charms/mutual_tls_interface/v0/mutual_tls.py
@@ -1,9 +1,9 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Library for the mutual-tls relation.
+"""Library for the cert-transfer relation.
 
-This library contains the Requires and Provides classes for handling the mutual-tls interface.
+This library contains the Requires and Provides classes for handling the cert-transfer interface.
 
 ## Getting Started
 From a charm directory, fetch the library using `charmcraft`:
@@ -78,7 +78,7 @@ if __name__ == "__main__":
 You can relate both charms by running:
 
 ```bash
-juju relate <mutual-tls provider charm> <mutual-tls requirer charm>
+juju relate <cert-transfer provider charm> <cert-transfer requirer charm>
 ```
 
 """

--- a/lib/charms/mutual_tls_interface/v0/mutual_tls.py
+++ b/lib/charms/mutual_tls_interface/v0/mutual_tls.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Library for the cert-transfer relation.
+"""Library for the certificate-exchange relation.
 
 This library contains the Requires and Provides classes for handling the cert-transfer interface.
 

--- a/tests/unit/charms/mutual_tls_interface/v0/test_mutual_tls_provides.py
+++ b/tests/unit/charms/mutual_tls_interface/v0/test_mutual_tls_provides.py
@@ -15,14 +15,14 @@ BASE_LIB_DIR = "lib.charms.mutual_tls_interface.v0.mutual_tls"
 
 class TestMutualTLSProvides(unittest.TestCase):
     def setUp(self):
-        self.unit_name = "mutual-tls-interface-provider/0"
+        self.unit_name = "cert-transfer-interface-provider/0"
         self.harness = testing.Harness(DummyMutualTLSProviderCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
 
     def create_mutual_tls_relation(self) -> int:
         relation_name = "certificates"
-        remote_app_name = "mutual-tls-requirer"
+        remote_app_name = "cert-transfer-requirer"
         relation_id = self.harness.add_relation(
             relation_name=relation_name,
             remote_app=remote_app_name,
@@ -43,7 +43,7 @@ class TestMutualTLSProvides(unittest.TestCase):
         )
 
         relation_data = self.harness.get_relation_data(
-            app_or_unit="mutual-tls-interface-provider/0",
+            app_or_unit="cert-transfer-interface-provider/0",
             relation_id=relation_id,
         )
         self.assertEqual(relation_data["certificate"], certificate)
@@ -62,7 +62,7 @@ class TestMutualTLSProvides(unittest.TestCase):
         self.harness.charm.mutual_tls.set_certificate(certificate=certificate, ca=ca, chain=chain)
 
         relation_data = self.harness.get_relation_data(
-            app_or_unit="mutual-tls-interface-provider/0",
+            app_or_unit="cert-transfer-interface-provider/0",
             relation_id=relation_id,
         )
         self.assertEqual(relation_data["certificate"], certificate)
@@ -91,13 +91,13 @@ class TestMutualTLSProvides(unittest.TestCase):
         self.harness.update_relation_data(
             relation_id=relation_id,
             key_values=relation_data,
-            app_or_unit="mutual-tls-interface-provider/0",
+            app_or_unit="cert-transfer-interface-provider/0",
         )
 
         self.harness.charm.mutual_tls.remove_certificate(relation_id=relation_id)
 
         relation_data = self.harness.get_relation_data(
-            app_or_unit="mutual-tls-interface-provider/0",
+            app_or_unit="cert-transfer-interface-provider/0",
             relation_id=relation_id,
         )
         assert "certificate" not in relation_data
@@ -114,13 +114,13 @@ class TestMutualTLSProvides(unittest.TestCase):
         self.harness.update_relation_data(
             relation_id=relation_id,
             key_values=relation_data,
-            app_or_unit="mutual-tls-interface-provider/0",
+            app_or_unit="cert-transfer-interface-provider/0",
         )
 
         self.harness.charm.mutual_tls.remove_certificate(relation_id=relation_id)
 
         relation_data = self.harness.get_relation_data(
-            app_or_unit="mutual-tls-interface-provider/0",
+            app_or_unit="cert-transfer-interface-provider/0",
             relation_id=relation_id,
         )
         assert "certificate" not in relation_data
@@ -137,13 +137,13 @@ class TestMutualTLSProvides(unittest.TestCase):
         self.harness.update_relation_data(
             relation_id=relation_id,
             key_values=relation_data,
-            app_or_unit="mutual-tls-interface-provider/0",
+            app_or_unit="cert-transfer-interface-provider/0",
         )
 
         self.harness.charm.mutual_tls.remove_certificate()
 
         relation_data = self.harness.get_relation_data(
-            app_or_unit="mutual-tls-interface-provider/0",
+            app_or_unit="cert-transfer-interface-provider/0",
             relation_id=relation_id,
         )
         assert "certificate" not in relation_data


### PR DESCRIPTION
# Description

Here we are changing the interface name from "mutual TLS" to "Cert Transfer".

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
