### PR TITLE
Fix broken library upload after name change

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - "main"
-    paths:
-      - "lib/charms/certificate_exchange_interface/v0/**"
 
 jobs:
   charmhub-upload:
@@ -26,4 +24,4 @@ jobs:
         env:
           CHARMCRAFT_AUTH: "${{ secrets.CHARMCRAFT_AUTH }}"
         run: |
-          charmcraft publish-lib charms.certificate_exchange_interface.v0.certificate_exchange
+          charmcraft publish-lib charms.certificate_exchange_interface.v1.certificate_exchange


### PR DESCRIPTION
# Description

Library upload was broken after name change, simply being skipped by GitHub. This change fixes the library path and removes the dependency on changes in the library to execute the upload.

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
