### PR TITLE
fix: Fix tests for logs when relation is not there

### DIFF
--- a/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_provides_v1.py
+++ b/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_provides_v1.py
@@ -91,9 +91,9 @@ class TestCertificateTransferProvidesV1:
 
         logs = [(record.levelname, record.module, record.message) for record in caplog.records]
         assert (
-            "WARNING",
+            "DEBUG",
             "certificate_transfer",
-            "At least 1 matching relation ID not found with the relation name 'certificate_transfer'",
+            "No active relations found with the relation name 'certificate_transfer'",
         ) in logs
 
     def test_given_unrelated_relation_when_add_certificates_then_error_is_logged(
@@ -376,9 +376,9 @@ the databags except using the public methods in the provider library and use ver
 
         logs = [(record.levelname, record.module, record.message) for record in caplog.records]
         assert (
-            "WARNING",
+            "DEBUG",
             "certificate_transfer",
-            "At least 1 matching relation ID not found with the relation name 'certificate_transfer'",
+            "No active relations found with the relation name 'certificate_transfer'",
         ) in logs
 
     def test_given_unrelated_relation_when_remove_certificate_then_error_is_logged(


### PR DESCRIPTION
# Description

This change fixes spam logs when there is not cert-transfer relation.
Unfortunately I was able to push directly to main, so this PR must review [this](https://github.com/canonical/certificate-transfer-interface/commit/0c60eef0f89ad7dc65d6088d9222fe64dbd5d4d9) commit too.
I fixed Branch rules.

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
